### PR TITLE
Compile Kotlin files at process-resources Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,14 @@
 							</annotationProcessorPaths>
 						</configuration>
 					</execution>
+
+					<execution>
+						<id>compile</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
When generating JPA Metamodels (the ones with classes ending with **_** character), they don't seem to have access to Kotlin classes.

See this comment:
https://github.com/mapstruct/mapstruct/issues/1298#issuecomment-346705908